### PR TITLE
fix: set default value of Hash to nil so further logic works

### DIFF
--- a/lib/logstash/filters/sparqldecode.rb
+++ b/lib/logstash/filters/sparqldecode.rb
@@ -33,6 +33,7 @@ class LogStash::Filters::SparqlDecode < LogStash::Filters::Base
         event.set("[http][request][sparql]", event.get("[http][request][body]"))
       elsif event.get("[url][query]")
         query_map = CGI::parse(event.get("[url][query]"))
+        query_map.default = nil
         query = query_map["query"] || query_map["update"]
         event.set("[http][request][sparql]", query) if query
       end


### PR DESCRIPTION
For some reason the Hash that CGI::parse returns is set to `[]`. `[]` is truthy, so doing `query_map["this_does_not_exist"] || query_map["update"]` will never give the latter, since `[]` evaluates to true. Kind of an insane default behaviour, if you ask me.

You can check this behaviour in a Ruby REPL of your choice:

```
irb(main):019> query_map = CGI::parse("content-type=application%2Fsparql-results%2Bjson&format=application%2Fsparql-results%2Bjson&update=%0A++++++++++INSERT+%7B%0A++++++++++++GRAPH+%3Chttp%3A%2F%2Fmu.semte.ch%2Fgraphs%2Forganizations%2Fintern-overheid%3E+%7B%0A++++++++++++++%3Fresource+%3Fp+%3Fo+.%0A++++++++++++%7D%0A++++++++++%7D+WHERE+%7B%0A++++++++++++SELECT+%3Fresource+%3Fp+%3Fo+WHERE+%7B%0A++++++++++++++GRAPH+%3Chttp%3A%2F%2Fmu.semte.ch%2Fgraphs%2Ftemp%2F7365b201-9115-11ef-b10a-8bea21026982%3E+%7B+%3Fresource+%3Fp+%3Fo+.+%7D%0A++++++++++++++FILTER+NOT+EXISTS+%7B%0A++++++++++++++++GRAPH+%3Chttp%3A%2F%2Fmu.semte.ch%2Fgraphs%2Forganizations%2Fintern-overheid%3E+%7B+%3Fresource+%3Fp+%3Fo+%7D%0A++++++++++++++%7D%0A++++++++++++%7D+LIMIT+2500%0A++++++++++%7D")
=> 
{"content-type"=>["application/sparql-results+json"],
...
irb(main):020> query = query_map["query"] || query_map["update"]
=> []
irb(main):021> query = query_map["update"] || query_map["query"]
=> ["\n          INSERT {\n            GRAPH <http://mu.semte.ch/graphs/organizations/intern-overheid> {\n              ?resource ?p ?o .\n            }\n          } WHERE {\n            SELECT ?resource ?p ?o WHERE {\n              GRAPH <http://mu.semte.ch/graphs/temp/7365b201-9115-11ef-b10a-8bea21026982> { ?r...
irb(main):022> query_map.default
=> []
irb(main):023> query_map.default = nil
=> nil
irb(main):024> query = query_map["query"] || query_map["update"]
=> ["\n          INSERT {\n            GRAPH <http://mu.semte.ch/graphs/organizations/intern-overheid> {\n              ?resource ?p ?o .\n            }\n          } WHERE {\n            SELECT ?resource ?p ?o WHERE {\n              GRAPH <http://mu.semte.ch/graphs/temp/7365b201-9115-11ef-b10a-8bea21026982> { ?r...
irb(main):025>
```