### PR TITLE
Deduplicate sparqldecode functionality

### DIFF
--- a/lib/logstash/filters/ipmap.rb
+++ b/lib/logstash/filters/ipmap.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
-require 'cgi'
 
 class LogStash::Filters::IpMap < LogStash::Filters::Base
 
@@ -27,25 +26,6 @@ class LogStash::Filters::IpMap < LogStash::Filters::Base
 
   public
   def filter(event)
-    begin
-      response_content_types = event.get("[http][response][headers][content-type]")
-      request_content_types = event.get("[http][request][headers][content-type]")
-      if response_content_types == "application/sparql-results+json"
-        # A SPARQL query was sent, let's enrich it'
-        if request_content_types && request_content_types == "application/sparql-query"
-          # POST with content-type sparql-update, get body
-          event.set("[http][request][sparql]", event.get("[http][request][body]"))
-        elsif event.get("[url][query]") && event.get("[url][query]")
-          query_map = CGI::parse(event.get("[url][query]"))
-          query = query_map["query"] || query_map["update"]
-          event.set("[http][request][sparql]", query) if query.first && query.first
-        else
-        end
-      end
-    rescue
-      puts "Failed to process SPARQL query for #{event}"
-    end
-
     begin
       my_ip = ""
       other_ip = ""

--- a/lib/logstash/filters/sparqldecode.rb
+++ b/lib/logstash/filters/sparqldecode.rb
@@ -7,19 +7,6 @@ class LogStash::Filters::SparqlDecode < LogStash::Filters::Base
 
   config_name "sparqldecode"
 
-# These values are hardcoded for now because of the need to switch source and dest ip fields based on direction
-#  # The fields where the IP and domain name of a service can be found. Used to fill the IP -> domain name map
-#  config :source_domain_field, :validate => :string, :required => true
-#  config :source_ip_field, :validate => :string, :required => true
-#
-#  # The field containing the IP to be resolved using the map we built
-#  config :dest_ip_field, :validate => :string, :required => true
-#  # The field where the domain name associated with the destination IP will be inserted
-#  config :dest_domain_field, :validate => :string, :required => true
-
-  # Mapping of IPs to Docker service names/domain names
-  attr_accessor :mapping
-
   public
   def register
   end

--- a/lib/logstash/filters/sparqldecode.rb
+++ b/lib/logstash/filters/sparqldecode.rb
@@ -17,7 +17,7 @@ class LogStash::Filters::SparqlDecode < LogStash::Filters::Base
       response_content_types = event.get("[http][response][headers][content-type]")
       request_content_types = event.get("[http][request][headers][content-type]")
       if response_content_types == "application/sparql-results+json"
-        # A SPARQL query was sent, let's enrich it'
+        # A SPARQL query was sent, let's enrich it
         if request_content_types == "application/sparql-query"
           # POST with content-type sparql-update, get body
           event.set("[http][request][sparql]", event.get("[http][request][body]"))

--- a/lib/logstash/filters/sparqldecode.rb
+++ b/lib/logstash/filters/sparqldecode.rb
@@ -13,17 +13,23 @@ class LogStash::Filters::SparqlDecode < LogStash::Filters::Base
 
   public
   def filter(event)
-    if event.get("[http][response][headers][content-type]") == "application/sparql-results+json"
-      # A SPARQL query was sent, let's enrich it'
-      if event.get("[http][request][headers][content-type]") == "application/sparql-query"
-        # POST with content-type sparql-update, get body
-        event.set("[http][request][sparql]", event.get("[http][request][body]"))
-      elsif event.get("[url][query]")
-        query_map = CGI::parse(event.get("[url][query]"))
-        query_map.default = nil
-        query = query_map["query"] || query_map["update"]
-        event.set("[http][request][sparql]", query) if query
+    begin
+      response_content_types = event.get("[http][response][headers][content-type]")
+      request_content_types = event.get("[http][request][headers][content-type]")
+      if response_content_types == "application/sparql-results+json"
+        # A SPARQL query was sent, let's enrich it'
+        if request_content_types == "application/sparql-query"
+          # POST with content-type sparql-update, get body
+          event.set("[http][request][sparql]", event.get("[http][request][body]"))
+        elsif event.get("[url][query]")
+          query_map = CGI::parse(event.get("[url][query]"))
+          query_map.default = nil
+          query = query_map["query"] || query_map["update"]
+          event.set("[http][request][sparql]", query) if query.first && query.first
+        end
       end
+    rescue
+      @logger.warn("Failed to process SPARQL query for #{event}")
     end
 
     filter_matched(event)

--- a/lib/logstash/filters/sparqldecode.rb
+++ b/lib/logstash/filters/sparqldecode.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "logstash/filters/base"
 require "logstash/namespace"
-require 'cgi'
+require "cgi"
 
 class LogStash::Filters::SparqlDecode < LogStash::Filters::Base
 


### PR DESCRIPTION
We have two filters in this repo: `ipmap` and `sparqldecode`. The former maps IPs to docker compose service names, the latter adds user-readable SPARQL queries to the Logstash events we display in Kibana.

The problem: the former was doing the latter's work, and the latter was never actually used.

This PR removes the SPARQL decoding functionality from `ipmap` and puts it solely in the `sparqldecode` filter. Now the two filters have a reason to exist, as they both do separate things.

The `app-http-logger` repository has a PR that ensures we now actually use the `sparqldecode` filter too.

https://github.com/redpencilio/app-http-logger/pull/20